### PR TITLE
Update WHM Reactions to include DRK Invul buff_id

### DIFF
--- a/GeneralTriggers/Qwert/General_WHM_everywhere.lua
+++ b/GeneralTriggers/Qwert/General_WHM_everywhere.lua
@@ -6471,6 +6471,7 @@ local tbl =
 					409,
 					1836,
 					811,
+					810
 				},
 				category = 3,
 				channelCheckSpellID = -1,
@@ -7272,6 +7273,7 @@ local tbl =
 					409,
 					1836,
 					811,
+					810
 				},
 				category = 3,
 				channelCheckSpellID = -1,

--- a/GeneralTriggers/Qwert/General_WHM_savage.lua
+++ b/GeneralTriggers/Qwert/General_WHM_savage.lua
@@ -5797,6 +5797,7 @@ local tbl =
 					409,
 					1836,
 					811,
+					810
 				},
 				category = 3,
 				channelCheckSpellID = -1,
@@ -6597,6 +6598,7 @@ local tbl =
 					409,
 					1836,
 					811,
+					810
 				},
 				category = 3,
 				channelCheckSpellID = -1,


### PR DESCRIPTION
Noticed that the buff_id was missing for WHM. It's already there for AST and SCH doesn't have anything in it's buff_id list, but I didn't know if that was on purpose or not.